### PR TITLE
PUT request fails with error of unknown user

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -197,7 +197,7 @@ Intercom.prototype.createUser = function(userObj, cb) {
 };
 
 Intercom.prototype.updateUser = function(userObj, cb) {
-  return this.request('PUT', 'users', userObj, cb);
+  return this.request('POST', 'users', userObj, cb);
 };
 
 Intercom.prototype.deleteUser = function(userObj, cb) {


### PR DESCRIPTION
A PUT request is the correct way to implement the API, however, after several tests to this method, I always received a 404 error.  According to the docs a create and update are both POST requests. 

http://doc.intercom.io/api/#create-or-update-company

After changing to a POST I was able to successfully call intercom
