### PR TITLE
Handle undefined date parameter in date helper

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -158,11 +158,15 @@ Intercom.prototype.request = function(method, path, parameters, cb) {
 /**
  * Helper method to create dates for intercom easily
  *
- * @param {Number  or Date} date - the date. Leave empty if you want the date set to now
+ * @param {Number  or Date} date - the date (in milliseconds if Number). Leave empty if you want the date set to now
  * @returns {Number} epoch - time in seconds since Epoch (how intercom handles dates)
  * @api public
  */
 Intercom.prototype.date = function(date) {
+  if (date === undefined) {
+    date = new Date();
+  }
+
   if (date && _.isDate(date) && date.getTime) {
     return Math.floor(date.getTime() / 1000);
   }


### PR DESCRIPTION
`intercom.date()` currently returns `NaN`