### PR TITLE
Fix updateTag request method

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -317,7 +317,7 @@ Intercom.prototype.createTag = function(tagObj, cb) {
 
 Intercom.prototype.updateTag = function(tagObj, cb) {
   // Note: tagObj should be empty
-  return this.request('PUT', 'tags', tagObj, cb);
+  return this.request('POST', 'tags', tagObj, cb);
 };
 
 // ### Segments


### PR DESCRIPTION
According to Intercom.io documentation the updateTag method should use POST instead of PUT.
https://doc.intercom.io/api/#create-and-update-tags