### PR TITLE
Fix user delete API call

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -241,7 +241,12 @@ Intercom.prototype.updateUser = function(userObj, cb) {
 };
 
 Intercom.prototype.deleteUser = function(userObj, cb) {
-  return this.request('DELETE', 'users', userObj, cb);
+  if (userObj && userObj.hasOwnProperty('id')) {
+    return this.request('DELETE', 'users' + '/' + userObj.id, {}, cb);
+  }
+  else {
+    return this.request('DELETE', 'users', userObj, cb);
+  }
 };
 
 Intercom.prototype.bulkAddUsers = function(userObj, cb) {


### PR DESCRIPTION

Following the latest intercom API docs the user id should be on the url instead of the http body.

curl -s https://api.intercom.io/users/5321a20f72cdbb4192000013 ...
