### PR TITLE
Fix parameters not being passed through when paging

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -175,7 +175,7 @@ Intercom.prototype.getPages = function(path, parameters, cb) {
 
   function allPagesPromises (totalPages) {
     return _.range(1, totalPages + 1).map(function (n) {
-      return self.request('GET', path, {page: n});
+      return self.request('GET', path, _.extend(parameters, {page: n}));
     });
   }
   function gatherPages (acc, result) {


### PR DESCRIPTION
This fixes passing parameters when retrieving a paged resource (e.g. all companies with a specific tag). The current behavior ignores the passed parameters and retrieves the entire resource. Now you can do things like this properly:

```
intercom.getPages('companies', {tag_id: 179707})
```