### PR TITLE
Update debug to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "homepage": "https://github.com/tarunc/intercom.io",
   "license": "MIT",
   "dependencies": {
-    "debug": "2.1.0",
+    "debug": "2.2.0",
     "lodash": "2.4.1",
     "q": "1.0.1",
     "qs": "2.3.1",


### PR DESCRIPTION
It looks like debug v2.1.0 requires a version of ms with a vulnerability [as reported on bitHound](https://www.bithound.io/github/tarunc/intercom.io/master/dependencies/npm#filter-insecure-dep). This PR updates debug to the latest version which includes the latest version of ms. 

- [x] Update package.json

I did some basic testing with the module with the updated debug and things look ok.