### PR TITLE
Extend result with intercom's ratelimit

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -147,8 +147,16 @@ Intercom.prototype.request = function(method, path, parameters, cb) {
       }
     }
 
+    var headers = res.headers;
+    var data = parsed || data;
+    data.meta = {
+      ratelimit_limit: headers['x-ratelimit-limit'],
+      ratelimit_remaining: headers['x-ratelimit-remaining'],
+      ratelimit_reset: headers['x-ratelimit-reset']
+    };
+
     // Resolve the promise
-    return deferred.resolve(parsed || data);
+    return deferred.resolve(data);
   });
 
   // Return the promise and promisify any callback provided


### PR DESCRIPTION
I wanted to overtake the ratelimit errors, so i created this little pull request. I think it's important too know this values, because intercom gives you penalty if ratelimit has been exceeded many times.