### PR TITLE
Update request to 2.74.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "lodash": "~4.3.0",
     "q": "~1.4.1",
     "qs": "~6.1.0",
-    "request": "~2.69.0"
+    "request": "~2.74.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
`tough-cookie` contains a vulnerability. `request` depend on `tough-cookie`, so we need `request` => 2.74.0 to get the fix. See https://nodesecurity.io/advisories/130.

It would be really good to merge this and release as soon as you can. Thanks.