### PR TITLE
Add timeout to http requests

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -13,7 +13,8 @@ var request = require('request'),
 // Define some sane default options
 // Right now we only have one endpoint for intercom data
 var defaultOptions = {
-  endpoint: 'https://api.intercom.io/'
+  endpoint: 'https://api.intercom.io/',
+  timeout: 10 * 1000 // ms
 };
 
 /**
@@ -94,7 +95,8 @@ Intercom.prototype.request = function(method, path, parameters, cb) {
 
   var requestOptions = {
     method: method,
-    url: url
+    url: url,
+    timeout: this.options.timeout
   };
 
   if (method === 'GET') {


### PR DESCRIPTION
Add a default very conservative timeout of 10 seconds, with support for changing it via options. This is good practice to avoid requests with very long timeouts.