### PR TITLE
Store the error details in IntercomError

### DIFF
--- a/lib/IntercomError.js
+++ b/lib/IntercomError.js
@@ -26,10 +26,11 @@ util.inherits(AbstractError, Error);
  *
  * @api private
  */
-function IntercomError(message) {
+function IntercomError(message, errors) {
   AbstractError.apply(this, arguments);
   this.name = 'IntercomError';
   this.message = message;
+  this.errors = data.errors;
 }
 
 /**

--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -135,10 +135,12 @@ Intercom.prototype.request = function(method, path, parameters, cb) {
         parsed = JSON.parse(data);
 
         if (parsed && (parsed.error || parsed.errors)) {
-          err = new IntercomError(data);
+          var errorCodes = '"' + parsed.errors.map(function (error) {
+              return error.code;
+            }).join('", "') + '"';
 
           // Reject the promise
-          return deferred.reject(err);
+          return deferred.reject(new IntercomError(errorCodes + ' error(s) from Intercom', parsed.errors));
         }
       } catch (exception) {
         // Reject the promise


### PR DESCRIPTION
This provides a bit nicer error message, and provides the detailed errors in a parsed format on the error object. 