### PR TITLE
Fix `data is not defined`

### DIFF
--- a/lib/IntercomError.js
+++ b/lib/IntercomError.js
@@ -30,7 +30,7 @@ function IntercomError(message, errors) {
   AbstractError.apply(this, arguments);
   this.name = 'IntercomError';
   this.message = message;
-  this.errors = data.errors;
+  this.errors = errors;
 }
 
 /**


### PR DESCRIPTION
The latest version crashes when creating an `IntercomError`