### PR TITLE
'DELETE' should not send body.

### DIFF
--- a/lib/intercom.io.js
+++ b/lib/intercom.io.js
@@ -97,7 +97,7 @@ Intercom.prototype.request = function(method, path, parameters, cb) {
     timeout: this.options.timeout
   };
 
-  if (method === 'GET') {
+  if (method === 'GET' || method === 'DELETE') {
     requestOptions.qs = parameters;
     requestOptions.headers = {
       'Accept': 'application/json'


### PR DESCRIPTION
As for GET, the DELETE method is not really expected to send a body.
Or at least, the Intercom API expects query params when issuing DELETE
requests.